### PR TITLE
Ensure that sensor does not fail badly when it is not configured.

### DIFF
--- a/src/test/java/com/pablissimo/sonar/TsLintSensorTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsLintSensorTest.java
@@ -54,6 +54,8 @@ public class TsLintSensorTest {
     @Before
     public void setUp() throws Exception {
         this.settings = mock(Settings.class);
+        when(this.settings.getString(TypeScriptPlugin.SETTING_TS_LINT_PATH)).thenReturn("/path/to/tslint");
+
         this.fileSystem = mock(FileSystem.class);
         this.perspectives = mock(ResourcePerspectives.class);
         this.issuable = mock(Issuable.class);
@@ -143,5 +145,16 @@ public class TsLintSensorTest {
         this.sensor.analyse(mock(Project.class), mock(SensorContext.class));
 
         assertEquals(1, capturedIssues.size());
+    }
+
+    @Test
+    public void analyse_doesNothingWhenNotConfigured() throws IOException {
+        when(this.settings.getString(TypeScriptPlugin.SETTING_TS_LINT_PATH)).thenReturn(null);
+
+        when(this.fileSystem.files(any(FilePredicate.class))).thenReturn(new ArrayList<File>());
+        this.sensor.analyse(mock(Project.class), mock(SensorContext.class));
+
+        verify(this.sensor, never()).writeConfiguration(anyString(), any(File.class), any(Charset.class));
+        verify(this.issuable, never()).addIssue(any(Issue.class));
     }
 }


### PR DESCRIPTION
Instead, it simply logs a warning that there is no path to tslint. This avoids failures
when only some projects in a Sonar installation intend to use the plugin.