### PR TITLE
Multiple code improvements - squid:S1854, squid:S1148, squid:S2386, squid:S2293, squid:S1488

### DIFF
--- a/src/main/java/com/pablissimo/sonar/LOCSensor.java
+++ b/src/main/java/com/pablissimo/sonar/LOCSensor.java
@@ -4,6 +4,9 @@ import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.Sensor;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
@@ -13,6 +16,8 @@ import org.sonar.api.measures.Measure;
 import org.sonar.api.resources.Project;
 
 public class LOCSensor implements Sensor {
+    private static final Logger LOG = LoggerFactory.getLogger(LOCSensor.class);
+
     private FileSystem fileSystem;
 
     /**
@@ -42,7 +47,7 @@ public class LOCSensor implements Sensor {
     public String toString() {
         return getClass().getSimpleName();
     }
-    
+
     protected BufferedReader getReaderFromFile(InputFile inputFile) throws FileNotFoundException {
         return new BufferedReader(new FileReader(inputFile.file()));
     }
@@ -53,9 +58,9 @@ public class LOCSensor implements Sensor {
         try {
             br = this.getReaderFromFile(inputFile);
 
-            boolean isEOF = false;
+            boolean isEOF;
             boolean isCommentOpen = false;
-            boolean isACommentLine = false;
+            boolean isACommentLine;
             do {
 
                 String line = br.readLine();
@@ -102,11 +107,9 @@ public class LOCSensor implements Sensor {
             br.close();
 
         } catch (FileNotFoundException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            LOG.error("File not found", e);
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            LOG.error("Error while reading BufferedReader", e);
         }
         return value;
     }

--- a/src/main/java/com/pablissimo/sonar/TsCoverageSensor.java
+++ b/src/main/java/com/pablissimo/sonar/TsCoverageSensor.java
@@ -113,7 +113,7 @@ public class TsCoverageSensor implements Sensor {
     }
 
     private void saveZeroValueForResource(org.sonar.api.resources.File resource, SensorContext context) {
-        PropertiesBuilder<Integer, Integer> lineHitsData = new PropertiesBuilder<Integer, Integer>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
+        PropertiesBuilder<Integer, Integer> lineHitsData = new PropertiesBuilder<>(CoreMetrics.COVERAGE_LINE_HITS_DATA);
 
         for (int x = 1; x < context.getMeasure(resource, CoreMetrics.LINES).getIntValue(); x++) {
             lineHitsData.add(x, 0);

--- a/src/main/java/com/pablissimo/sonar/TsLintSensor.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintSensor.java
@@ -54,9 +54,7 @@ public class TsLintSensor implements Sensor {
     }
 
     public boolean shouldExecuteOnProject(Project project) {
-        boolean toReturn = hasFilesToAnalyze();
-
-        return toReturn;
+        return hasFilesToAnalyze();
     }
 
     private boolean hasFilesToAnalyze() {
@@ -85,7 +83,7 @@ public class TsLintSensor implements Sensor {
 
         RuleQuery ruleQuery = RuleQuery.create().withRepositoryKey(TsRulesDefinition.REPOSITORY_NAME);
         Collection<Rule> allRules = this.ruleFinder.findAll(ruleQuery);
-        HashSet<String> ruleNames = new HashSet<String>();
+        HashSet<String> ruleNames = new HashSet<>();
         for (Rule rule : allRules) {
             ruleNames.add(rule.getKey());
         }

--- a/src/main/java/com/pablissimo/sonar/TypeScriptLanguage.java
+++ b/src/main/java/com/pablissimo/sonar/TypeScriptLanguage.java
@@ -6,7 +6,7 @@ public class TypeScriptLanguage extends AbstractLanguage {
     public static final String LANGUAGE_NAME = "TypeScript";
     public static final String LANGUAGE_KEY = "ts";
     public static final String[] LANGUAGE_EXTENSIONS = { "ts", "tsx" };
-    public static final String LANGUAGE_DEFINITION_EXTENSION = "d.ts";
+    protected static final String LANGUAGE_DEFINITION_EXTENSION = "d.ts";
 
     public TypeScriptLanguage(){
         super(LANGUAGE_KEY, LANGUAGE_NAME);

--- a/src/main/java/com/pablissimo/sonar/model/TsLintConfig.java
+++ b/src/main/java/com/pablissimo/sonar/model/TsLintConfig.java
@@ -7,7 +7,7 @@ public class TsLintConfig {
     private Map<String, Object> rules;
 
     public TsLintConfig() {
-        this.rules = new HashMap<String, Object>();
+        this.rules = new HashMap<>();
     }
 
     public Map<String, Object> getRules() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S2386 - Mutable fields should not be "public static".
squid:S2293 - The diamond operator ("<>") should be used.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S2386
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava