### PR TITLE
Fixed issue with tslint standard output of json. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ hs_err_pid*
 
 #Custom stuff
 sample.tslint.json
+.idea

--- a/src/main/java/com/pablissimo/sonar/TsLintExecutorImpl.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintExecutorImpl.java
@@ -12,67 +12,67 @@ import org.sonar.api.utils.command.StreamConsumer;
 public class TsLintExecutorImpl implements TsLintExecutor {
     public static final int MAX_COMMAND_LENGTH = 4096;
     private static final Logger LOG = LoggerFactory.getLogger(TsLintExecutorImpl.class);
-    
+
     private StringBuilder stdOut;
     private StringBuilder stdErr;
 
     private static Command getBaseCommand(String pathToTsLint, String configFile, String rulesDir) {
-        Command command = 
+        Command command =
                 Command
                 .create("node")
                 .addArgument(pathToTsLint)
                 .addArgument("--format")
                 .addArgument("json");
-        
+
         if (rulesDir != null && rulesDir.length() > 0) {
             command
                 .addArgument("--rules-dir")
                 .addArgument(rulesDir);
         }
-        
+
         command
             .addArgument("--config")
             .addArgument(configFile)
             .setNewShell(false);
-            
+
         return command;
     }
-    
+
     public String execute(String pathToTsLint, String configFile, String rulesDir, List<String> files, Integer timeoutMs) {
         // New up a command that's everything we need except the files to process
         // We'll use this as our reference for chunking up files
         int baseCommandLength = getBaseCommand(pathToTsLint, configFile, rulesDir).toCommandLine().length();
         int availableForBatching = MAX_COMMAND_LENGTH - baseCommandLength;
-        
+
         List<List<String>> batches = new ArrayList<List<String>>();
         List<String> currentBatch = new ArrayList<String>();
         batches.add(currentBatch);
-        
+
         int currentBatchLength = 0;
         for (int i = 0; i < files.size(); i++) {
             String nextPath = files.get(i).trim();
-            
+
             // +1 for the space we'll be adding between filenames
-            if (currentBatchLength + nextPath.length() + 1 > availableForBatching) { 
+            if (currentBatchLength + nextPath.length() + 1 > availableForBatching) {
                 // Too long to add to this batch, create new
                 currentBatch = new ArrayList<String>();
                 currentBatchLength = 0;
                 batches.add(currentBatch);
             }
-            
+
             currentBatch.add(nextPath);
             currentBatchLength += nextPath.length() + 1;
         }
-        
+
         LOG.debug("Split " + files.size() + " files into " + batches.size() + " batches for processing");
-        
+
         this.stdOut = new StringBuilder();
         this.stdErr = new StringBuilder();
 
         StreamConsumer stdOutConsumer = new StreamConsumer() {
             public void consumeLine(String line) {
                 LOG.trace("TsLint Out: " + line);
-                stdOut.append(line + "\n");
+                stdOut.append(line);
             }
         };
 
@@ -86,25 +86,25 @@ public class TsLintExecutorImpl implements TsLintExecutor {
         for (int i = 0; i < batches.size(); i++) {
             List<String> thisBatch = batches.get(i);
             Command thisCommand = getBaseCommand(pathToTsLint, configFile, rulesDir);
-            
+
             for (int fileIndex = 0; fileIndex < thisBatch.size(); fileIndex++) {
                 thisCommand.addArgument(thisBatch.get(fileIndex));
             }
-            
+
             LOG.debug("Executing TsLint with command: " + thisCommand.toCommandLine());
-            
+
             // Timeout is specified per file, not per batch (which can vary a lot)
             // so multiply it up
             this.createExecutor().execute(thisCommand, stdOutConsumer, stdErrConsumer, timeoutMs * thisBatch.size());
         }
-        
+
         String rawOutput = stdOut.toString();
-        
+
         // TsLint returns nonsense for its JSON output when faced with multiple files
         // so we need to fix it up before we do anything else
         return "[" + rawOutput.replaceAll("\\]\\[", "],[") + "]";
     }
-    
+
     protected CommandExecutor createExecutor() {
         return CommandExecutor.create();
     }


### PR DESCRIPTION
Additional EOL was interfearing with json parsing. Removed that.

`
StreamConsumer stdOutConsumer = new StreamConsumer() {
            public void consumeLine(String line) {
                LOG.trace("TsLint Out: " + line);
                stdOut.append(line,"\n");
            }
        };
`

to 

`
StreamConsumer stdOutConsumer = new StreamConsumer() {
            public void consumeLine(String line) {
                LOG.trace("TsLint Out: " + line);
                stdOut.append(line);
            }
        };
`