### PR TITLE
Add new setting "sonar.ts.ignoreNotFound"

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The plugin has so far *only been tested on Windows* and it'll be no surprise if 
 <tr><td>sonar.ts.tslintconfigpath</td><td><b>Mandatory</b></td><td>Path to the tslint.json file that configures the rules to be used in linting</td></tr>
 <tr><td>sonar.ts.excludetypedefinitionfiles</td><td><b>Optional</b></td><td>Excludes .d.ts files from analysis, defaults to true</td></tr>
 <tr><td>sonar.ts.forceZeroCoverage</td><td><b>Optional</b></td><td>Forces code coverage percentage to zero when no report is supplied, defaults to false</td></tr>
+<tr><td>sonar.ts.ignoreNotFound</td><td><b>Optional</b></td><td>Don't set code coverage percentage to zero when file is not found in report, defaults to false</td></tr>
 <tr><td>sonar.ts.tslinttimeout</td><td><b>Optional</b></td><td>Max time to wait for TsLint to finish processing a single file (in milliseconds), defaults to 60 seconds</td></tr>
 <tr><td>sonar.ts.tslintrulesdir</td><td><b>Optional</b></td><td>Path to a folder containing custom TsLint rules referenced in tslint.json</td></tr>
 <tr><td>sonar.ts.lcov.reportpath</td><td><b>Optional</b></td><td>Path to an LCOV code-coverage report to be included in analysis</td></tr>

--- a/src/main/java/com/pablissimo/sonar/TsCoverageSensor.java
+++ b/src/main/java/com/pablissimo/sonar/TsCoverageSensor.java
@@ -84,6 +84,8 @@ public class TsCoverageSensor implements Sensor {
 
         LCOVParser parser = getParser(moduleFileSystem.baseDir());
         Map<String, CoverageMeasuresBuilder> coveredFiles = parser.parseFile(lcovFile);
+        
+        final boolean ignoreNotFound = isIgnoreNotFoundActivated();
 
         for (File file : moduleFileSystem.files(this.filePredicates.hasLanguage(TypeScriptLanguage.LANGUAGE_KEY))) {
             try {
@@ -94,7 +96,7 @@ public class TsCoverageSensor implements Sensor {
                     for (Measure measure : fileCoverage.createMeasures()) {
                         context.saveMeasure(resource, measure);
                     }
-                } else {
+                } else if (!ignoreNotFound) {
                     // colour all lines as not executed
                     saveZeroValueForResource(resource, context);
                 }
@@ -133,6 +135,10 @@ public class TsCoverageSensor implements Sensor {
 
     private boolean isForceZeroCoverageActivated() {
         return settings.getBoolean(TypeScriptPlugin.SETTING_FORCE_ZERO_COVERAGE);
+    }
+
+    private boolean isIgnoreNotFoundActivated() {
+        return settings.getBoolean(TypeScriptPlugin.SETTING_IGNORE_NOT_FOUND);
     }
 
     private boolean isLCOVReportProvided() {

--- a/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
+++ b/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
@@ -91,6 +91,7 @@ import org.sonar.api.*;
 public class TypeScriptPlugin extends SonarPlugin {
     public static final String SETTING_EXCLUDE_TYPE_DEFINITION_FILES = "sonar.ts.excludetypedefinitionfiles";
     public static final String SETTING_FORCE_ZERO_COVERAGE = "sonar.ts.forceZeroCoverage";
+    public static final String SETTING_IGNORE_NOT_FOUND = "sonar.ts.ignoreNotFound";
     public static final String SETTING_TS_LINT_PATH = "sonar.ts.tslintpath";
     public static final String SETTING_TS_LINT_CONFIG_PATH = "sonar.ts.tslintconfigpath";
     public static final String SETTING_TS_LINT_TIMEOUT = "sonar.ts.tslinttimeout";

--- a/src/test/java/com/pablissimo/sonar/TsCoverageSensorTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsCoverageSensorTest.java
@@ -133,6 +133,24 @@ public class TsCoverageSensorTest {
     }
 
     @Test
+    public void savesNoCoverage_IfNotFoundFilesAreIgnored() {        
+        when(this.settings.getBoolean(TypeScriptPlugin.SETTING_IGNORE_NOT_FOUND)).thenReturn(true);
+        
+        Measure linesMeasure = mock(Measure.class);
+        when(this.context.getMeasure(eq(this.sonarFile), eq(CoreMetrics.LINES))).thenReturn(linesMeasure);
+
+        Measure nclocLines = mock(Measure.class);
+        when(nclocLines.getIntValue()).thenReturn(5);
+        when(nclocLines.getValue()).thenReturn(5.0);
+        when(this.context.getMeasure(eq(this.sonarFile), eq(CoreMetrics.NCLOC))).thenReturn(nclocLines);
+
+        this.sensor.analyse(mock(Project.class), this.context);
+        verify(context, never()).saveMeasure(eq(this.sonarFile), any(Measure.class));
+        verify(context, never()).saveMeasure(eq(this.sonarFile), eq(CoreMetrics.LINES_TO_COVER), any(Double.class));
+        verify(context, never()).saveMeasure(eq(this.sonarFile), eq(CoreMetrics.UNCOVERED_LINES), any(Double.class));
+    }
+
+    @Test
     public void savesCoverage_IfParserOutputHasDetailsForFile() {
         when(this.file.getAbsolutePath()).thenReturn("path");
 


### PR DESCRIPTION
I've had the problem that the coverage was also calculated for the test files and the page object files which was always at 0%, because this files don't appear in the karma report.
With this setting only files within the report get a coverage.
The default behavior was not changed.
