### PR TITLE
Make TSLint execution configurable (enable/disable)

### DIFF
--- a/src/main/java/com/pablissimo/sonar/TsLintSensor.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintSensor.java
@@ -41,13 +41,13 @@ public class TsLintSensor implements Sensor {
     }
 
     public boolean shouldExecuteOnProject(Project project) {
-        return hasFilesToAnalyze();
+        return settings.getBoolean(TypeScriptPlugin.SETTING_TS_LINT_ENABLED) && hasFilesToAnalyze();
     }
 
     private boolean hasFilesToAnalyze() {
         return fileSystem.files(this.filePredicates.hasLanguage(TypeScriptLanguage.LANGUAGE_KEY)).iterator().hasNext();
     }
-    
+
     private String getPath(String settingKey, String defaultValue) {
         // Prefer the specified path
         String toReturn = settings.getString(settingKey);
@@ -60,27 +60,27 @@ public class TsLintSensor implements Sensor {
         else {
             LOG.debug("Found " + settingKey + " Lint path to be '" + toReturn + "'");
         }
-        
+
         return getAbsolutePath(toReturn);
     }
-    
+
     protected String getAbsolutePath(String toReturn) {
         if (toReturn != null) {
             File candidateFile = new java.io.File(toReturn);
             if (!candidateFile.isAbsolute()) {
                 candidateFile = new java.io.File(this.fileSystem.baseDir().getAbsolutePath(), toReturn);
             }
-            
+
             if (!doesFileExist(candidateFile)) {
                 return null;
             }
 
             return candidateFile.getAbsolutePath();
         }
-        
+
         return null;
     }
-    
+
     protected boolean doesFileExist(File f) {
         return f.exists();
     }
@@ -89,7 +89,7 @@ public class TsLintSensor implements Sensor {
         String pathToTsLint = this.getPath(TypeScriptPlugin.SETTING_TS_LINT_PATH, TSLINT_FALLBACK_PATH);
         String pathToTsLintConfig = this.getPath(TypeScriptPlugin.SETTING_TS_LINT_CONFIG_PATH, CONFIG_FILENAME);
         String rulesDir = this.getPath(TypeScriptPlugin.SETTING_TS_LINT_RULES_DIR, null);
-        
+
         Integer tsLintTimeoutMs = Math.max(5000, settings.getInt(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT));
 
         if (pathToTsLint == null) {
@@ -142,7 +142,7 @@ public class TsLintSensor implements Sensor {
             }
 
             String filePath = batchIssues[0].getName();
-            
+
             if (!fileMap.containsKey(filePath)) {
                 LOG.warn("TsLint reported issues against a file that wasn't sent to it - will be ignored: " + filePath);
                 continue;

--- a/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
+++ b/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
@@ -7,6 +7,14 @@ import org.sonar.api.*;
 
 @Properties({
     @Property(
+        key = TypeScriptPlugin.SETTING_TS_LINT_ENABLED,
+        type = PropertyType.BOOLEAN,
+        defaultValue = "true",
+        name = "Enable TSLint",
+        description = "Run TSLint on SonarQube analysis",
+        project = true
+    ),
+    @Property(
         key = TypeScriptPlugin.SETTING_TS_LINT_PATH,
         defaultValue = "",
         name = "Path to TSLint",
@@ -92,6 +100,7 @@ public class TypeScriptPlugin extends SonarPlugin {
     public static final String SETTING_EXCLUDE_TYPE_DEFINITION_FILES = "sonar.ts.excludetypedefinitionfiles";
     public static final String SETTING_FORCE_ZERO_COVERAGE = "sonar.ts.forceZeroCoverage";
     public static final String SETTING_IGNORE_NOT_FOUND = "sonar.ts.ignoreNotFound";
+    public static final String SETTING_TS_LINT_ENABLED = "sonar.ts.tslintenabled";
     public static final String SETTING_TS_LINT_PATH = "sonar.ts.tslintpath";
     public static final String SETTING_TS_LINT_CONFIG_PATH = "sonar.ts.tslintconfigpath";
     public static final String SETTING_TS_LINT_TIMEOUT = "sonar.ts.tslinttimeout";

--- a/src/test/java/com/pablissimo/sonar/TypeScriptPluginTest.java
+++ b/src/test/java/com/pablissimo/sonar/TypeScriptPluginTest.java
@@ -52,7 +52,7 @@ public class TypeScriptPluginTest {
         Annotation annotation = plugin.getClass().getAnnotations()[0];
         Properties propertiesAnnotation = (Properties) annotation;
 
-        assertEquals(8, propertiesAnnotation.value().length);
+        assertEquals(9, propertiesAnnotation.value().length);
 
         Property[] properties = propertiesAnnotation.value();
         assertNotNull(findPropertyByName(properties,
@@ -61,6 +61,8 @@ public class TypeScriptPluginTest {
                 TypeScriptPlugin.SETTING_FORCE_ZERO_COVERAGE));
         assertNotNull(findPropertyByName(properties,
                 TypeScriptPlugin.SETTING_LCOV_REPORT_PATH));
+        assertNotNull(findPropertyByName(properties,
+            TypeScriptPlugin.SETTING_TS_LINT_ENABLED));
         assertNotNull(findPropertyByName(properties,
                 TypeScriptPlugin.SETTING_TS_LINT_PATH));
         assertNotNull(findPropertyByName(properties,


### PR DESCRIPTION
We want to disable the tslint run since we break our build on tslint errors anyway. So, calling tslint in the SonarQube analysis doesn't make sense.
