### PR TITLE
Fix #74, #78 - null pointer exn thrown on no tslint output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.pablissimo.sonar</groupId>
   <artifactId>sonar-typescript-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>0.96-SNAPSHOT</version>
+  <version>0.97-SNAPSHOT</version>
 
   <name>TypeScript</name>
   <description>Analyse TypeScript projects</description>

--- a/src/main/java/com/pablissimo/sonar/TsLintParserImpl.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintParserImpl.java
@@ -23,6 +23,11 @@ public class TsLintParserImpl implements TsLintParser {
         
         for (String batch : toParse) {
             TsLintIssue[] batchIssues = gson.fromJson(getFixedUpOutput(batch), TsLintIssue[].class);
+            
+            if (batchIssues == null) {
+                continue;
+            }
+            
             for (TsLintIssue batchIssue : batchIssues) {
                 allIssues.add(batchIssue);
             }

--- a/src/test/java/com/pablissimo/sonar/TsLintParserTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsLintParserTest.java
@@ -67,4 +67,14 @@ public class TsLintParserTest {
         assertEquals(1, issues.size());
         assertEquals(2, issues.get("Tools.ts").size());
     }
+    
+    @Test
+    public void parseAGoodProjectWithNoIssues() {
+        List<String> toParse = new ArrayList<String>();
+        toParse.add("");
+                
+        Map<String, List<TsLintIssue>> issues = new TsLintParserImpl().parse(toParse);
+        
+        assertEquals(0, issues.size());        
+    }
 }


### PR DESCRIPTION
Fixes a null reference exception when empty tslint output.