### PR TITLE
Fix #48 - Angular CLI-generated LCOV files fail to map to source TypeScript

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,9 @@
     <testResources>
         <testResource>
             <directory>${project.basedir}/src/test/resources</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
         </testResource>
     </testResources>
     

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.pablissimo.sonar</groupId>
   <artifactId>sonar-typescript-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>0.97-SNAPSHOT</version>
+  <version>0.98-SNAPSHOT</version>
 
   <name>TypeScript</name>
   <description>Analyse TypeScript projects</description>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
   </dependencies>
 
   <build>
+    <testResources>
+        <testResource>
+            <directory>${project.basedir}/src/test/resources</directory>
+        </testResource>
+    </testResources>
+    
     <plugins>
       <plugin>
         <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>

--- a/src/main/java/com/pablissimo/sonar/LCOVParserImpl.java
+++ b/src/main/java/com/pablissimo/sonar/LCOVParserImpl.java
@@ -150,6 +150,15 @@ public class LCOVParserImpl implements LCOVParser {
     FileData fileData = null;
     // some tools (like Istanbul, Karma) provide relative paths, so let's consider them relative to project directory
     InputFile inputFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(filePath));
+    
+    // Try to accommodate Angular projects that, when the angular template loader's used
+    // by checking for a ! in the filepath if the path isn't found - have a bash at seeking
+    // everything after the ! as a second fallback pass
+    if (inputFile == null && filePath.contains("!") && (filePath.indexOf("!") + 1) < filePath.length()) {
+        String amendedPath = filePath.substring(filePath.indexOf("!") + 1);
+        inputFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(amendedPath));
+    }
+    
     if (inputFile != null) {
       fileData = files.get(inputFile);
       if (fileData == null) {

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -25,7 +25,7 @@ public class LCOVParserImplTest {
         this.sensorContext = SensorContextTester.create(new File(""));
                 
         this.inputFile = 
-                new DefaultInputFile("", "/path/to/file.ts")
+                new DefaultInputFile("", "path/to/file.ts")
                     .setLanguage(TypeScriptLanguage.LANGUAGE_KEY)
                     .setLines(3);
         
@@ -137,11 +137,11 @@ public class LCOVParserImplTest {
         try {
             File lcovFile = new File(lcovUrl.toURI());
             System.out.println(lcovFile == null ? "couldn't turn it into a file" : "got a file!");
+            
+            System.out.println("And it " + (lcovFile.exists() ? "exists!" : "doesn't exist"));
             return lcovFile;
         } 
         catch (URISyntaxException e) {
-            e.printStackTrace();
-            System.out.println("Didn't manage it " + e.getMessage());
             return null;
         }
     }

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -136,10 +136,12 @@ public class LCOVParserImplTest {
         
         try {
             File lcovFile = new File(lcovUrl.toURI());
+            System.out.println(lcovFile == null ? "couldn't turn it into a file" : "got a file!");
             return lcovFile;
         } 
         catch (URISyntaxException e) {
             e.printStackTrace();
+            System.out.println("Didn't manage it " + e.getMessage());
             return null;
         }
     }

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -132,13 +132,9 @@ public class LCOVParserImplTest {
     
     private File resource(String testName) {        
         URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("./lcov/" + testName + ".lcov");
-        System.out.println(lcovUrl.getFile());
         
         try {
             File lcovFile = new File(lcovUrl.toURI());
-            System.out.println(lcovFile == null ? "couldn't turn it into a file" : "got a file!");
-            
-            System.out.println("And it " + (lcovFile.exists() ? "exists!" : "doesn't exist"));
             return lcovFile;
         } 
         catch (URISyntaxException e) {

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -1,0 +1,144 @@
+package com.pablissimo.sonar;
+
+import static org.junit.Assert.*;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.sensor.coverage.NewCoverage;
+import org.sonar.api.batch.sensor.coverage.internal.DefaultCoverage;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+
+public class LCOVParserImplTest {
+    LOCSensor sensor;
+    
+    SensorContextTester sensorContext;
+    DefaultInputFile inputFile;
+    
+    @Before
+    public void setUp() throws Exception {
+        this.sensorContext = SensorContextTester.create(new File(""));
+                
+        this.inputFile = 
+                new DefaultInputFile("", "/path/to/file.ts")
+                    .setLanguage(TypeScriptLanguage.LANGUAGE_KEY)
+                    .setLines(3);
+        
+        this.sensorContext.fileSystem().add(this.inputFile);
+    }
+    
+    @Test
+    public void parsesBasicLcovFiles() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("basic");
+        DefaultCoverage c = (DefaultCoverage) coverage.get(this.inputFile);
+        
+        assertEquals((Integer) 3, c.hitsByLine().get(1));
+        assertEquals((Integer) 0, c.hitsByLine().get(2));
+        assertEquals((Integer) 1, c.hitsByLine().get(3));
+        
+        assertEquals(3, c.linesToCover());
+    }
+    
+    @Test
+    public void parsesAngularTemplateLoaderOutput() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("angular");
+        DefaultCoverage c = (DefaultCoverage) coverage.get(this.inputFile);
+        
+        assertEquals((Integer) 3, c.hitsByLine().get(1));
+        assertEquals((Integer) 0, c.hitsByLine().get(2));
+        assertEquals((Integer) 1, c.hitsByLine().get(3));
+        
+        assertEquals(3, c.linesToCover());
+    }
+    
+    @Test
+    public void handlesNoContent() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("blank");
+       
+        assertNotNull(coverage);
+        assertEquals(0, coverage.size());
+    }
+    
+    @Test
+    public void handlesNoLineHitsForASingleFile() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("nolinehits");
+        DefaultCoverage c = (DefaultCoverage) coverage.get(this.inputFile);
+        
+        assertEquals(1, coverage.size());
+        
+        assertNotNull(c);
+        assertNull(c.hitsByLine().get(1));
+        assertNull(c.hitsByLine().get(2));
+        assertNull(c.hitsByLine().get(3));
+    }
+    
+    @Test
+    public void ignoresFilesNotPartOfAnalysisSet() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("existingandnot");
+        DefaultCoverage c = (DefaultCoverage) coverage.get(this.inputFile);
+        
+        assertNotNull(c);
+        assertEquals(1, coverage.size());
+    }
+    
+    @Test
+    public void handlesFilesEndingWithExclamationMarkIfNotPartOfSet() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("angularendswithbang");
+        
+        assertNotNull(coverage);
+        assertEquals(0, coverage.size());
+    }
+    
+    @Test
+    public void handlesOutOfRangeLineNumbers() {
+        Map<InputFile, NewCoverage> coverage = executeForTestCase("outofrangelines");
+        DefaultCoverage c = (DefaultCoverage) coverage.get(this.inputFile);
+
+        assertNotNull(c);
+        assertEquals(1, coverage.size());
+        
+        assertEquals((Integer) 3, c.hitsByLine().get(1));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void createThrowsWhenFileDoesNotExist() {
+        File nonExistent = new File("whatever");
+        LCOVParserImpl.create(this.sensorContext, nonExistent);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFileThrowsWhenFileDoesNotExist() {
+        File nonExistent = new File("whatever");
+        LCOVParser parser = getParser(resource("basic"));
+        
+        parser.parseFile(nonExistent);
+    }
+    
+    private Map<InputFile, NewCoverage> executeForTestCase(String testName) {
+        File lcovFile = resource(testName);
+        LCOVParser parser = getParser(lcovFile);
+        
+        return parser.parseFile(lcovFile);
+    }
+    
+    private LCOVParser getParser(File lcovFile) {
+        return LCOVParserImpl.create(this.sensorContext, lcovFile);
+    }
+    
+    private File resource(String testName) {        
+        URL lcovUrl = LCOVParserImplTest.class.getResource("/lcov/" + testName + ".lcov");;
+        
+        try {
+            File lcovFile = new File(lcovUrl.toURI());
+            return lcovFile;
+        } 
+        catch (URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -131,7 +131,8 @@ public class LCOVParserImplTest {
     }
     
     private File resource(String testName) {        
-        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("lcov/" + testName + ".lcov");
+        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("./lcov/" + testName + ".lcov");
+        System.out.println(lcovUrl.getFile());
         
         try {
             File lcovFile = new File(lcovUrl.toURI());

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -131,7 +131,7 @@ public class LCOVParserImplTest {
     }
     
     private File resource(String testName) {        
-        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("./lcov/" + testName + ".lcov");;
+        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("lcov/" + testName + ".lcov");;
         
         try {
             File lcovFile = new File(lcovUrl.toURI());

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -131,13 +131,14 @@ public class LCOVParserImplTest {
     }
     
     private File resource(String testName) {        
-        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("lcov/" + testName + ".lcov");;
+        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("lcov/" + testName + ".lcov");
         
         try {
             File lcovFile = new File(lcovUrl.toURI());
             return lcovFile;
         } 
         catch (URISyntaxException e) {
+            e.printStackTrace();
             return null;
         }
     }

--- a/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/LCOVParserImplTest.java
@@ -131,7 +131,7 @@ public class LCOVParserImplTest {
     }
     
     private File resource(String testName) {        
-        URL lcovUrl = LCOVParserImplTest.class.getResource("/lcov/" + testName + ".lcov");;
+        URL lcovUrl = LCOVParserImplTest.class.getClassLoader().getResource("./lcov/" + testName + ".lcov");;
         
         try {
             File lcovFile = new File(lcovUrl.toURI());

--- a/src/test/resources/lcov/angular.lcov
+++ b/src/test/resources/lcov/angular.lcov
@@ -1,0 +1,5 @@
+SF:/path/to/template/loader.js!/path/to/file.ts
+DA:1,3
+DA:2,0
+DA:3,1
+end_of_record

--- a/src/test/resources/lcov/angular.lcov
+++ b/src/test/resources/lcov/angular.lcov
@@ -1,4 +1,4 @@
-SF:/path/to/template/loader.js!/path/to/file.ts
+SF:path/to/template/loader.js!path/to/file.ts
 DA:1,3
 DA:2,0
 DA:3,1

--- a/src/test/resources/lcov/angularendswithbang.lcov
+++ b/src/test/resources/lcov/angularendswithbang.lcov
@@ -1,0 +1,3 @@
+SF:/path/to/template/loader.js!
+DA:1,3
+end_of_record

--- a/src/test/resources/lcov/angularendswithbang.lcov
+++ b/src/test/resources/lcov/angularendswithbang.lcov
@@ -1,3 +1,3 @@
-SF:/path/to/template/loader.js!
+SF:path/to/template/loader.js!
 DA:1,3
 end_of_record

--- a/src/test/resources/lcov/basic.lcov
+++ b/src/test/resources/lcov/basic.lcov
@@ -1,0 +1,5 @@
+SF:/path/to/file.ts
+DA:1,3
+DA:2,0
+DA:3,1
+end_of_record

--- a/src/test/resources/lcov/basic.lcov
+++ b/src/test/resources/lcov/basic.lcov
@@ -1,4 +1,4 @@
-SF:/path/to/file.ts
+SF:path/to/file.ts
 DA:1,3
 DA:2,0
 DA:3,1

--- a/src/test/resources/lcov/existingandnot.lcov
+++ b/src/test/resources/lcov/existingandnot.lcov
@@ -1,0 +1,8 @@
+SF:/path/to/file.ts
+DA:1,3
+DA:2,0
+DA:3,1
+end_of_record
+SF:/path/to/nonexistent/file.ts
+DA:1,1
+end_of_record

--- a/src/test/resources/lcov/existingandnot.lcov
+++ b/src/test/resources/lcov/existingandnot.lcov
@@ -1,8 +1,8 @@
-SF:/path/to/file.ts
+SF:path/to/file.ts
 DA:1,3
 DA:2,0
 DA:3,1
 end_of_record
-SF:/path/to/nonexistent/file.ts
+SF:path/to/nonexistent/file.ts
 DA:1,1
 end_of_record

--- a/src/test/resources/lcov/nolinehits.lcov
+++ b/src/test/resources/lcov/nolinehits.lcov
@@ -1,0 +1,2 @@
+SF:/path/to/file.ts
+end_of_record

--- a/src/test/resources/lcov/nolinehits.lcov
+++ b/src/test/resources/lcov/nolinehits.lcov
@@ -1,2 +1,2 @@
-SF:/path/to/file.ts
+SF:path/to/file.ts
 end_of_record

--- a/src/test/resources/lcov/outofrangelines.lcov
+++ b/src/test/resources/lcov/outofrangelines.lcov
@@ -1,4 +1,4 @@
-SF:/path/to/file.ts
+SF:path/to/file.ts
 DA:0,3
 DA:1,3
 DA:4,3

--- a/src/test/resources/lcov/outofrangelines.lcov
+++ b/src/test/resources/lcov/outofrangelines.lcov
@@ -1,0 +1,5 @@
+SF:/path/to/file.ts
+DA:0,3
+DA:1,3
+DA:4,3
+end_of_record


### PR DESCRIPTION
Fixes #48 and adds some unit test coverage for the LCOVParser (to be expanded on).