### PR TITLE
Fix Issue #75 - support --project and --type-check

### DIFF
--- a/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
@@ -21,7 +21,7 @@ public class TsLintExecutorConfig {
         toReturn.setPathToTsLint(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_PATH, TSLINT_FALLBACK_PATH));
         toReturn.setConfigFile(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_CONFIG_PATH, CONFIG_FILENAME));
         toReturn.setRulesDir(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_RULES_DIR, null));
-        toReturn.setPathToTsConfig(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_TSCONFIG_PATH, null));
+        toReturn.setPathToTsConfig(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_PROJECT_PATH, null));
         
         toReturn.setTimeoutMs(Math.max(5000, settings.getInt(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT)));
         toReturn.setShouldPerformTypeCheck(settings.getBoolean(TypeScriptPlugin.SETTING_TS_LINT_TYPECHECK));

--- a/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
@@ -1,10 +1,36 @@
 package com.pablissimo.sonar;
 
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Settings;
+
 public class TsLintExecutorConfig {
+    public static final String CONFIG_FILENAME = "tslint.json";
+    public static final String TSLINT_FALLBACK_PATH = "node_modules/tslint/bin/tslint";
+    
     private String pathToTsLint;
     private String configFile;
     private String rulesDir;
+    private String pathToTsConfig;
+    private boolean shouldPerformTypeCheck;
+    
     private Integer timeoutMs;
+    
+    public static TsLintExecutorConfig fromSettings(Settings settings, SensorContext ctx, PathResolver resolver) {
+        TsLintExecutorConfig toReturn = new TsLintExecutorConfig();
+        
+        toReturn.setPathToTsLint(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_PATH, TSLINT_FALLBACK_PATH));
+        toReturn.setConfigFile(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_CONFIG_PATH, CONFIG_FILENAME));
+        toReturn.setRulesDir(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_RULES_DIR, null));
+        toReturn.setTimeoutMs(Math.max(5000, settings.getInt(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT)));
+        toReturn.setPathToTsConfig(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_TSCONFIG_PATH, null));
+        toReturn.setShouldPerformTypeCheck(settings.getBoolean(TypeScriptPlugin.SETTING_TS_LINT_TYPECHECK));
+        
+        return toReturn;
+    }
+    
+    public Boolean useTsConfigInsteadOfFileList() {
+        return this.getPathToTsConfig() != null;
+    }
 
     public String getPathToTsLint() {
         return pathToTsLint;
@@ -36,5 +62,21 @@ public class TsLintExecutorConfig {
 
     public void setTimeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
+    }
+
+    public String getPathToTsConfig() {
+        return pathToTsConfig;
+    }
+
+    public void setPathToTsConfig(String pathToTsConfig) {
+        this.pathToTsConfig = pathToTsConfig;
+    }
+
+    public boolean shouldPerformTypeCheck() {
+        return this.shouldPerformTypeCheck;
+    }
+
+    public void setShouldPerformTypeCheck(boolean performTypeCheck) {
+        this.shouldPerformTypeCheck = performTypeCheck;
     }
 }

--- a/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
+++ b/src/main/java/com/pablissimo/sonar/TsLintExecutorConfig.java
@@ -21,15 +21,16 @@ public class TsLintExecutorConfig {
         toReturn.setPathToTsLint(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_PATH, TSLINT_FALLBACK_PATH));
         toReturn.setConfigFile(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_CONFIG_PATH, CONFIG_FILENAME));
         toReturn.setRulesDir(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_RULES_DIR, null));
-        toReturn.setTimeoutMs(Math.max(5000, settings.getInt(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT)));
         toReturn.setPathToTsConfig(resolver.getPath(ctx, TypeScriptPlugin.SETTING_TS_LINT_TSCONFIG_PATH, null));
+        
+        toReturn.setTimeoutMs(Math.max(5000, settings.getInt(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT)));
         toReturn.setShouldPerformTypeCheck(settings.getBoolean(TypeScriptPlugin.SETTING_TS_LINT_TYPECHECK));
         
         return toReturn;
     }
     
     public Boolean useTsConfigInsteadOfFileList() {
-        return this.getPathToTsConfig() != null;
+        return this.pathToTsConfig != null && !this.pathToTsConfig.isEmpty();
     }
 
     public String getPathToTsLint() {

--- a/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
+++ b/src/main/java/com/pablissimo/sonar/TypeScriptPlugin.java
@@ -123,7 +123,7 @@ public class TypeScriptPlugin implements Plugin {
     public static final String SETTING_LCOV_REPORT_PATH = "sonar.ts.lcov.reportpath";
     public static final String SETTING_TS_RULE_CONFIGS = "sonar.ts.ruleconfigs";
     public static final String SETTING_TS_LINT_TYPECHECK = "sonar.ts.tslinttypecheck";
-    public static final String SETTING_TS_LINT_TSCONFIG_PATH = "sonar.ts.tslinttsconfigpath";
+    public static final String SETTING_TS_LINT_PROJECT_PATH = "sonar.ts.tslintprojectpath";
 
     @Override
     public void define(Context ctx) {

--- a/src/test/java/com/pablissimo/sonar/TsLintExecutorConfigTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsLintExecutorConfigTest.java
@@ -1,0 +1,133 @@
+package com.pablissimo.sonar;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Settings;
+
+public class TsLintExecutorConfigTest {
+    
+    private TsLintExecutorConfig getNewConfig() {
+        return new TsLintExecutorConfig();
+    }
+    
+    @Test
+    public void canGetSetPathToTsLint() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setPathToTsLint("My path");
+        
+        assertEquals("My path",  config.getPathToTsLint());
+    }
+    
+    @Test
+    public void canGetSetPathToTsLintConfig() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setConfigFile("My path");
+        
+        assertEquals("My path",  config.getConfigFile());
+    }
+    
+    @Test
+    public void canGetSetRulesDir() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setRulesDir("My path");
+        
+        assertEquals("My path",  config.getRulesDir());
+    }
+    
+    @Test
+    public void canGetSetTimeout() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setTimeoutMs(12);
+        
+        assertEquals((Integer) 12, config.getTimeoutMs());
+    }
+    
+    @Test
+    public void canGetSetTsConfigPath() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setPathToTsConfig("My path");
+        
+        assertEquals("My path",  config.getPathToTsConfig());
+    }
+    
+    @Test
+    public void canGetSetTypeCheck() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setShouldPerformTypeCheck(true);
+        
+        assertTrue(config.shouldPerformTypeCheck());
+    }
+    
+    @Test
+    public void useTsConfigInsteadOfFileList_returnsTrue_ifPathToTsConfigSet() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setPathToTsConfig("My path");
+        
+        assertTrue(config.useTsConfigInsteadOfFileList());
+    }
+    
+    @Test
+    public void useTsConfigInsteadOfFileList_returnsFalse_ifPathToTsConfigNotSet() {
+        TsLintExecutorConfig config = getNewConfig();
+        config.setPathToTsConfig("");
+        
+        assertFalse(config.useTsConfigInsteadOfFileList());
+    }
+    
+    @Test
+    public void fromSettings_initialisesFromSettingsAndResolver() {
+        Settings settings = new Settings();
+        settings.setProperty(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT, 12000);
+        settings.setProperty(TypeScriptPlugin.SETTING_TS_LINT_TYPECHECK, true);
+        
+        PathResolver resolver = mock(PathResolver.class);
+        
+        when(resolver.getPath(any(SensorContext.class), 
+                               eq(TypeScriptPlugin.SETTING_TS_LINT_PATH), 
+                               eq(TsLintExecutorConfig.TSLINT_FALLBACK_PATH))
+        ).thenReturn("tslint");
+        
+        when(resolver.getPath(any(SensorContext.class), 
+                               eq(TypeScriptPlugin.SETTING_TS_LINT_CONFIG_PATH), 
+                               eq(TsLintExecutorConfig.CONFIG_FILENAME))
+        ).thenReturn("tslint.json");
+
+        when(resolver.getPath(any(SensorContext.class), 
+                               eq(TypeScriptPlugin.SETTING_TS_LINT_RULES_DIR), 
+                               eq((String) null))
+        ).thenReturn("rulesdir");
+        
+        when(resolver.getPath(any(SensorContext.class), 
+                               eq(TypeScriptPlugin.SETTING_TS_LINT_TSCONFIG_PATH), 
+                               eq((String) null))
+        ).thenReturn("tsconfig.json");
+        
+        TsLintExecutorConfig config = TsLintExecutorConfig.fromSettings(settings, SensorContextTester.create(new File("")), resolver);
+        
+        assertEquals("tslint", config.getPathToTsLint());
+        assertEquals("tslint.json", config.getConfigFile());
+        assertEquals("rulesdir", config.getRulesDir());
+        assertEquals("tsconfig.json", config.getPathToTsConfig());
+        
+        assertTrue(config.shouldPerformTypeCheck());
+        assertEquals((Integer) 12000, config.getTimeoutMs());
+    }
+    
+    @Test
+    public void fromSettings_setsTimeoutTo5000msMinimum_ifSetToLess() {
+        Settings settings = new Settings();
+        settings.setProperty(TypeScriptPlugin.SETTING_TS_LINT_TIMEOUT, 1000);
+        
+        PathResolver resolver = mock(PathResolver.class);
+
+        TsLintExecutorConfig config = TsLintExecutorConfig.fromSettings(settings, SensorContextTester.create(new File("")), resolver);
+
+        assertEquals((Integer) 5000, config.getTimeoutMs());
+    }
+}

--- a/src/test/java/com/pablissimo/sonar/TsLintExecutorConfigTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsLintExecutorConfigTest.java
@@ -104,7 +104,7 @@ public class TsLintExecutorConfigTest {
         ).thenReturn("rulesdir");
         
         when(resolver.getPath(any(SensorContext.class), 
-                               eq(TypeScriptPlugin.SETTING_TS_LINT_TSCONFIG_PATH), 
+                               eq(TypeScriptPlugin.SETTING_TS_LINT_PROJECT_PATH), 
                                eq((String) null))
         ).thenReturn("tsconfig.json");
         


### PR DESCRIPTION
* Adds support for two new options:

  - ```sonar.ts.tslintprojectpath``` - set to 'tsconfig.json' or similar, the path to your TypeScript configuration file describing what files to compile and lint
  - ```sonar.ts.tslinttypecheck``` - true/false, defaults to false - if true, requests ```tslint``` perform a type-check too, which allows certain rules requiring type information to work