### PR TITLE
Fixing scenario with multiple "!"s in the LCOV path.

### DIFF
--- a/src/main/java/com/pablissimo/sonar/LCOVParserImpl.java
+++ b/src/main/java/com/pablissimo/sonar/LCOVParserImpl.java
@@ -153,9 +153,9 @@ public class LCOVParserImpl implements LCOVParser {
     
     // Try to accommodate Angular projects that, when the angular template loader's used
     // by checking for a ! in the filepath if the path isn't found - have a bash at seeking
-    // everything after the ! as a second fallback pass
-    if (inputFile == null && filePath.contains("!") && (filePath.indexOf("!") + 1) < filePath.length()) {
-        String amendedPath = filePath.substring(filePath.indexOf("!") + 1);
+    // everything after the last ! as a second fallback pass
+    if (inputFile == null && filePath.contains("!") && (filePath.lastIndexOf("!") + 1) < filePath.length()) {
+        String amendedPath = filePath.substring(filePath.lastIndexOf("!") + 1);
         inputFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(amendedPath));
     }
     


### PR DESCRIPTION
We have SF lines in the LCOV files generated by angular cli looking like:

SF:/Users/xxx/xxx/xxxxx/yyyy/app/node_modules/angular2-template-loader/index.js!/Users/xxx/xxx/xxxxx/yyyy/app/node_modules/tslint-loader/index.js!/Users/xxx/xxx/xxxxx/yyyy/app/src/app/questions/loader.ts

So looking at the part of the path after the first ! won't solve our problem, however looking at part of the path after the final ! would.