### PR TITLE
add encoding rule (#157)

### DIFF
--- a/samples/basic-setup/tslint.json
+++ b/samples/basic-setup/tslint.json
@@ -97,6 +97,7 @@
             "check-operator",
             "check-separator",
             "check-type"
-        ]
+        ],
+        "encoding": true
     }
 }

--- a/samples/using-existing-tslint-output/tslint.json
+++ b/samples/using-existing-tslint-output/tslint.json
@@ -97,6 +97,7 @@
             "check-operator",
             "check-separator",
             "check-type"
-        ]
+        ],
+        "encoding": true
     }
 }

--- a/src/main/resources/tslint/tslint-rules.properties
+++ b/src/main/resources/tslint/tslint-rules.properties
@@ -754,3 +754,9 @@ whitespace.name=Inappropriate whitespace between tokens
 whitespace.severity=MINOR
 whitespace.debtFunc=CONSTANT_ISSUE
 whitespace.debtScalar=5min
+
+encoding=true
+encoding.name=Enforces UTF-8 file encoding
+encoding.severity=MINOR
+encoding.debtFunc=CONSTANT_ISSUE
+encoding.debtScalar=1min

--- a/src/test/java/com/pablissimo/sonar/TypeScriptRuleProfileTest.java
+++ b/src/test/java/com/pablissimo/sonar/TypeScriptRuleProfileTest.java
@@ -38,6 +38,7 @@ public class TypeScriptRuleProfileTest {
                 "completed-docs",
                 "curly",
                 "cyclomatic-complexity",
+                "encoding",
                 "eofline",
                 "file-header",
                 "forin",


### PR DESCRIPTION
cf my question this pull request adds the encoding rule : https://palantir.github.io/tslint/rules/encoding/

did a mvn clean test and result was OK