### PR TITLE
Updated Maven Config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
         <version>1.0-beta-1</version>
         <executions>
           <execution>
+          	<phase>package</phase>
             <goals>
               <goal>native2ascii</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
   <inceptionYear>2013</inceptionYear>
   <url>https://github.com/pablissimo/SonarTsPlugin</url>
   
-  <organisation>
+  <organization>
     <name>Paul O'Neill (pablissimo) and contributors</name>
     <url>https://github.com/pablissimo/SonarTsPlugin</url>
-  </organisation>
+  </organization>
   
   <developers>
     <developer>


### PR DESCRIPTION
Hello there,

I provide two minor Corrections of this Project when working with Eclipse IDE.

First fix corrects misspelling (organisation vs. organization).
Without second fix, Eclipse (latest Oxygen DSL Release with STS + EclEmma) complains about
>  Plugin execution not covered by lifecycle configuration: org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii (execution: default, phase: process-classes)

Greets,
M3ssman

