### PR TITLE
fixing null pointer exception when no report path provided

### DIFF
--- a/src/main/java/com/pablissimo/sonar/TsCoverageSensorImpl.java
+++ b/src/main/java/com/pablissimo/sonar/TsCoverageSensorImpl.java
@@ -39,9 +39,12 @@ public class TsCoverageSensorImpl implements TsCoverageSensor {
      */
     private static List<String> parseReportsProperty(String propertyValue) {
         List<String> reportPaths = new ArrayList<>();
-        for (String path : propertyValue.split(",")) {
-            if (!path.trim().isEmpty()) {
-                reportPaths.add(path.trim());
+
+        if (StringUtils.isNotBlank(propertyValue)) {
+            for (String path : propertyValue.split(",")) {
+                if (!path.trim().isEmpty()) {
+                    reportPaths.add(path.trim());
+                }
             }
         }
 

--- a/src/test/java/com/pablissimo/sonar/TsCoverageSensorImplTest.java
+++ b/src/test/java/com/pablissimo/sonar/TsCoverageSensorImplTest.java
@@ -74,6 +74,18 @@ public class TsCoverageSensorImplTest {
     }
 
     @Test
+    public void savesNothing_IfNullReportPathAndSettingDisabled() {
+        when(this.settings.getString(TypeScriptPlugin.SETTING_LCOV_REPORT_PATH)).thenReturn(null);
+        when(this.settings.getBoolean(TypeScriptPlugin.SETTING_FORCE_ZERO_COVERAGE)).thenReturn(false);
+        
+        this.sensor.execute(this.context, null);
+
+        for (int i = 1; i <= this.file.lines(); i++) {
+            assertNull(this.context.lineHits(this.file.key(), CoverageType.UNIT, i));
+        }
+    }
+
+    @Test
     public void doesNotCallParser_WhenNoLCOVPathSupplied() {
         when(this.settings.getString(TypeScriptPlugin.SETTING_LCOV_REPORT_PATH)).thenReturn("");
         


### PR DESCRIPTION
Several of my builds were breaking when I updated to the latest version yesterday. There was a null pointer exception being thrown when no report path was provided. I added a test to reproduce the bug and then added the fix in `parseReportsProperty()`, I did notice that there is no default value for the `TypeScriptPlugin.SETTING_LCOV_REPORT_PATH` property in `TypeScriptPlugin.java`. It could have been easily fixed by setting the default value to an empty string but I wasn't sure if you left it that way on purpose so I just fixed it in `TsCoverageSensorImpl` instead. Here is the error I was receving:

```##[error]ERROR: Error during SonarQube Scanner execution
##[error]java.lang.NullPointerException
##[error]at com.pablissimo.sonar.TsCoverageSensorImpl.parseReportsProperty(TsCoverageSensorImpl.java:42)
##[error]at com.pablissimo.sonar.TsCoverageSensorImpl.execute(TsCoverageSensorImpl.java:152)
##[error]at com.pablissimo.sonar.CombinedCoverageSensor.execute(CombinedCoverageSensor.java:33)
##[error]at org.sonar.scanner.sensor.SensorWrapper.analyse(SensorWrapper.java:53)
##[error]at org.sonar.scanner.phases.SensorsExecutor.executeSensor(SensorsExecutor.java:57)
##[error]at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:49)
##[error]at org.sonar.scanner.phases.AbstractPhaseExecutor.execute(AbstractPhaseExecutor.java:78)
##[error]at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:182)
##[error]at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142)
##[error]at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127)
##[error]at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:247)
##[error]at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:242)
##[error]at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:240)
##[error]at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:232)
##[error]at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142)
##[error]at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127)
##[error]at org.sonar.scanner.task.ScanTask.execute(ScanTask.java:47)
##[error]at org.sonar.scanner.task.TaskContainer.doAfterStart(TaskContainer.java:86)
##[error]at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142)
##[error]at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127)
##[error]at org.sonar.scanner.bootstrap.GlobalContainer.executeTask(GlobalContainer.java:115)
##[error]at org.sonar.batch.bootstrapper.Batch.executeTask(Batch.java:116)
##[error]at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:62)
##[error]at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
##[error]at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
##[error]at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
##[error]at java.lang.reflect.Method.invoke(Unknown Source)
##[error]at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60)
##[error]at com.sun.proxy.$Proxy0.execute(Unknown Source)
##[error]at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:233)
##[error]at org.sonarsource.scanner.api.EmbeddedScanner.runAnalysis(EmbeddedScanner.java:151)
##[error]at org.sonarsource.scanner.cli.Main.runAnalysis(Main.java:110)
##[error]at org.sonarsource.scanner.cli.Main.execute(Main.java:74)
##[error]at org.sonarsource.scanner.cli.Main.main(Main.java:61)
##[error]ERROR:
##[error]ERROR: Re-run SonarQube Scanner using the -X switch to enable full debug logging.
##[error]The SonarQube Scanner did not complete successfully```